### PR TITLE
Remove fail-suppressing `|| true` from npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "scripts": {
     "build": "pnpm -r --parallel build",
     "dev": "pnpm -r --parallel dev",
-    "lint": "eslint . --ext .ts,.tsx || true",
-    "typecheck": "tsc -b || true",
-    "format": "prettier --write . || true",
+    "lint": "eslint . --ext .ts,.tsx",
+    "typecheck": "tsc -b",
+    "format": "prettier --write .",
     "generate:exemplo": "tsx apps/api/scripts/generateExemplo.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- allow lint, typecheck, and format scripts to surface failures by dropping `|| true`

## Testing
- `pnpm lint` (fails: ESLint couldn't find a config file)
- `pnpm typecheck` (fails: missing tsconfig)
- `pnpm format` (fails: syntax error in malformed file)


------
https://chatgpt.com/codex/tasks/task_e_689dc092c3dc832c963c55b929ab3b5f